### PR TITLE
An update to S3AIR itself, including some changes.

### DIFF
--- a/org.sonic3air.Sonic3AIR.json
+++ b/org.sonic3air.Sonic3AIR.json
@@ -1,8 +1,8 @@
 {
     "app-id" : "org.sonic3air.Sonic3AIR",
-    "runtime" : "org.gnome.Platform",
-    "runtime-version" : "40",
-    "sdk" : "org.gnome.Sdk",
+    "runtime" : "org.freedesktop.Platform",
+    "runtime-version" : "21.08",
+    "sdk" : "org.freedesktop.Sdk",
     "command" : "sonic3air",
     "finish-args" : [
         "--share=ipc",
@@ -26,16 +26,11 @@
         "/share/man",
         "/share/pkgconfig",
         "*.la",
-        "*.a",
-        "/lib/girepository-1.0",
-        "/share/gir-1.0",
-        "/bin/gtk4*",
-        "/bin/pango*",
-        "/bin/sassc"
+        "*.a"
     ],
     "modules" : [
         {
-            "name" : "libadwaita",
+            "name" : "libhandy",
             "buildsystem" : "meson",
             "config-opts" : [
                 "-Dexamples=false",
@@ -45,8 +40,8 @@
             "sources" : [
                 {
                     "type" : "git",
-                    "url" : "https://gitlab.gnome.org/GNOME/libadwaita.git",
-                    "commit" : "ffb6b435c7da83c210a8f8a53af5082f6ed3816b"
+                    "url" : "https://gitlab.gnome.org/GNOME/libhandy.git",
+                    "commit" : "f8626427acebfa08b2b4ee1166d51e416d3d7407"
                 }
             ]
         },
@@ -57,14 +52,16 @@
                 "install -Dp -m 755 sonic3air /app/bin/sonic3air",
                 "install -Dp -m 755 sonic3air_linux /app/bin/sonic3air_linux",
                 "install -Dp -m 644 libdiscord_game_sdk.so /app/lib/libdiscord_game_sdk.so",
+                "cp -r bonus /app/bin",
                 "cp -r data /app/bin",
+                "cp -r doc /app/bin",
                 "install -Dp -m 644 config.json /app/bin/config.json"
             ],
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://github.com/Kekun/sonic3air-launcher/releases/download/v21.04.24.0-flathub/sonic3air_preview.tar.gz",
-                    "sha256" : "998ffdc1b7879681ee6bc67bebfaa05a201cb642a7bac520365c5cb20235cd4a"
+                    "url" : "https://github.com/HugLifeTiZ/sonic3air-launcher/releases/download/v21.09.12.0-flathub/sonic3air_game.tar.gz",
+                    "sha256" : "43c31721b3abf048d79c070da6592b2f04234730a27b78002f387afad41deb50"
                 },
                 {
                     "type" : "script",
@@ -83,9 +80,8 @@
             "sources" : [
                 {
                     "type" : "git",
-                    "url" : "https://github.com/Kekun/sonic3air-launcher.git",
-                    "branch" : "main",
-                    "commit" : "711904992931774daeec490ea251b96e1f732f1d"
+                    "url" : "https://github.com/HugLifeTiZ/sonic3air-launcher.git",
+                    "branch" : "main"
                 }
             ]
         }


### PR DESCRIPTION
These changes may be controversial, but I hope they and the rationale behind them are well received.

First, the easy part: Sonic 3 A.I.R. is updated to the latest release, v21.09.12.0. Right now the data is hosted on my repo, but if we gotta move it somewhere else, no big deal to me.

Next, the part right in the middle of easy and controversial. The reason I changed the runtime is mainly for convention; every game that handles all of its own rendering targets the FreeDesktop platform (or if not all of them, a vast majority). But we have a companion launcher here, and the FreeDesktop platform does not have GTK4, only GTK3.

So that takes me to the controversial part. I pushed the launcher *backwards* from Adwaita (and GTK4) to Handy (and GTK3). The reasons for this are a complex blend of practical and ideological, and I struggle to word them with consideration to the work that you have already done on packaging S3AIR. But you deserve for me to make a good faith effort, so here I go.

I don't think that you meant to target Adwaita as a means of making S3AIR's Flathub package be only for GNOME. I think you targeted Adwaita because you're comfortable with it as a graphical toolkit, and you wanted to make a launcher to improve the user experience of playing S3AIR. And honestly, it's a fantastic idea that I think was well-executed. It's why I bothered at all to push it back rather than just advocating for cutting it out.

Not only that, but I could tell that you had a pretty fantastic idea for theming the launcher. Normally, I strongly dislike it when apps that are meant to be part of my main workflow try to do their own thing theme-wise, but S3AIR is a game that renders everything itself, so the custom style is appropriate in that context; it's a prelude to a game that's going to draw everything itself anyways. Unfortunately, in the Adwaita version, the idea doesn't really shake out right on my environment.

![20210921-230216](https://user-images.githubusercontent.com/4130673/134287319-b70ae07a-0918-4c9b-9c41-3858f4dbbaff.png)

That's XFCE with Picom as my compositor, and that's after *trying* to make GTK4 play nice with it and failing. I would hate to imagine what it would look like on KDE, or a standalone window manager. If this was meant to be for a custom repo only available to GNOME users, that would be fine, but Flathub serves every Linux desktop, so I felt that pushing the launcher back to GTK3 and Handy was important to make sure that the experience you made is better-polished on non-GNOME environments, even if it can't be perfect on all of them. And it's not that I think that it's invalid to have apps that are meant to be only for GNOME on Flathub, but this should not be one of those apps.

Anyways, that was really long-winded and I apologize for that, but I hope it explains why I bothered to push the launcher back to Handy and why I would like those changes to be merged here.

Thanks.