### PR TITLE
Simplify script entry

### DIFF
--- a/org.sonic3air.Sonic3AIR.json
+++ b/org.sonic3air.Sonic3AIR.json
@@ -69,7 +69,6 @@
                 {
                     "type" : "script",
                     "commands" : [
-                        "#!/bin/sh",
                         "sonic3air-launcher && /app/bin/sonic3air_linux"
                     ],
                     "dest-filename" : "sonic3air"


### PR DESCRIPTION
Not necessary because builder recognize bash script