### PR TITLE
update Sonic3AIR version to 24.02.02 and update gnome runtime to version 46

### DIFF
--- a/org.sonic3air.Sonic3AIR.json
+++ b/org.sonic3air.Sonic3AIR.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.sonic3air.Sonic3AIR",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "43",
+    "runtime-version" : "46",
     "sdk" : "org.gnome.Sdk",
     "command" : "sonic3air",
     "finish-args" : [
@@ -62,8 +62,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://github.com/Eukaryot/sonic3air/releases/download/v22.09.10.0-stable/sonic3air_game.tar.gz",
-                    "sha256" : "2c052dbd4e823a9700ac700f0fcf3deca943effd06004c52363844b5b0409634"
+                    "url" : "https://github.com/Eukaryot/sonic3air/releases/download/v24.02.02.0-stable/sonic3air_game.tar.gz",
+                    "sha256" : "45e97c48513a7b466f5c55e766abad49c859ba0c7334f570da7cba2f5b143469"
                 },
                 {
                     "type" : "script",


### PR DESCRIPTION
Updates Sonic3AIR to the more recent release 24.02.02   and changes the gnome runtime up from the unsupported 43 version to the supported version 46.

I've tested locally and the new version seems to build and run without issue with gnome runtime 46